### PR TITLE
resolve the problem with the not existing `file`

### DIFF
--- a/4depcheck/tool/open_source/retirejs.py
+++ b/4depcheck/tool/open_source/retirejs.py
@@ -57,7 +57,12 @@ class RetireJS:
         output = []
         for vul_product in raw_json:
             if vul_product["results"] is not None:
-                file_path = vul_product["file"]
+                
+                if vul_product["file"] is not None:
+                    file_path = vul_product["file"]
+                else:
+                    file_path = 'N/A'
+                
                 for result in vul_product["results"]:
                     product = result["component"]
                     version = result["version"]


### PR DESCRIPTION
just resolve the problem with
```
Traceback (most recent call last):
  File "4depcheck.py", line 39, in <module>
    main(DepCheckCLIParser())
  File "4depcheck.py", line 29, in main
    full_report = run_tools(path_to_analyze=parsed_args.get_dir())
  File "/opt/app/tool/orchestrator.py", line 29, in run_tools
    retirejs_report = RetireJS(path=path_to_analyze).run_retirejs()
  File "/opt/app/tool/open_source/retirejs.py", line 39, in run_retirejs
    nodejs_vuln_report = self._generate_report(nodejs_raw_json_output, "nodejs")
  File "/opt/app/tool/open_source/retirejs.py", line 60, in _generate_report
    file_path = vul_product["file"]
KeyError: 'file'
```